### PR TITLE
Enable ci setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank issue
+about: Create an issue without a template.
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Tell us about broken, incorrect, or inconsistent behavior.
+
+---
+
+#### Describe the bug
+〈Replace this text with a clear and concise description of the bug.〉
+
+
+#### Steps to reproduce
+〈Replace this text with a code snippet or minimal working example [MWE] to
+replicate your problem, using one of the [datasets shipped with MNE-Python],
+preferably the one called [sample].
+If you can't replicate on a built-in dataset, provide also
+a link to a small, anonymized portion of your data that does yield the error.〉
+
+[MWE]: https://en.wikipedia.org/wiki/Minimal_Working_Example
+[built-in datasets]: https://mne.tools/dev/overview/datasets_index.html
+[sample]: https://mne.tools/dev/overview/datasets_index.html#sample
+
+
+#### Expected results
+〈Replace this text with a clear and concise description of what you expected to
+happen.〉
+
+
+#### Actual results
+〈Replace this text with the actual output, traceback, screenshot, or other
+description of the results.〉
+
+
+#### Additional information
+〈Replace this text with information about your system. For example through
+using MNE-Python and running `mne.sys_info()` and pasting the output here.〉

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+
+---
+
+If your issue is a usage question, please consider asking on the
+[MNE Forum](https://mne.discourse.group) instead of opening an issue.
+
+#### Describe the problem
+Please provide a clear and concise description of the problem.
+
+
+#### Describe your solution
+A clear and concise description of what you want to happen.
+
+
+#### Describe possible alternatives
+A clear and concise description of any alternative solutions or features you have considered.
+
+
+#### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Thanks for contributing. If this is your first time,
+make sure to read the [contributing guide.](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md)
+
+PR Description
+--------------
+
+Describe your PR here
+
+Merge checklist
+---------------
+
+Maintainer, please confirm the following before merging:
+
+- [ ] All comments resolved
+- [ ] This is not your own PR
+- [ ] All CIs are happy
+- [ ] PR title starts with [MRG]
+- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
+- [ ] PR description includes phrase "closes <#issue-number>"

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -1,0 +1,13 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-20.04
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/dev/index.html
+          circleci-jobs: build_docs
+          job-title: Check the rendered docs here!

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,156 @@
+name: 'unit_tests'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  # Run style tests
+  style:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ 3.9 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pip
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade --upgrade-strategy eager -r requirements.txt
+          pip install --upgrade --upgrade-strategy eager -r requirements_testing.txt
+      - name: Run style & documentation tests
+        run: make pep
+
+  # Run installation tests
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.7, 3.8, 3.9 ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade --upgrade-strategy eager -r requirements.txt
+          pip install --upgrade --upgrade-strategy eager -r requirements_testing.txt
+
+      # build with sdist directly
+      - uses: actions/checkout@v2
+      - name: Build sdist
+        run: python setup.py sdist
+      - name: Install sdist
+        run: pip install ./dist/mne-icalabel-*
+      - name: Clean up working directory
+        run: rm -rf ./*
+      - name: Try importing mne_icalabel
+        run: python -c 'import mne_icalabel; print(mne_icalabel.__version__)'
+      - name: Remove sdist install
+        run: pip uninstall -y mne-icalabel
+      # build with build wheet
+      - uses: actions/checkout@v2
+      - name: Build wheel
+        run: python setup.py bdist_wheel
+      - name: Install wheel
+        run: pip install ./dist/mne_icalabel-*.whl
+      - name: Clean up working directory
+        run: rm -rf ./*
+      - name: Try importing mne_icalabel
+        run: python -c 'import mne_icalabel; print(mne_icalabel.__version__)'
+      - name: Remove wheel install
+        run: pip uninstall -y mne-icalabel
+
+      - uses: actions/checkout@v2
+      - name: Test extras install
+        run: |
+          pip install .[full]
+          python -c 'import mne_icalabel; print(mne_icalabel.__version__)'
+
+  # Run unit tests
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+            mne-version: mne-main
+          - os: ubuntu-latest
+            python-version: 3.9
+            mne-version: mne-main
+          - os: macos-latest
+            python-version: 3.9
+            mne-version: mne-main
+
+    env:
+      TZ: Europe/Berlin
+      FORCE_COLOR: true
+      DISPLAY: ':99.0'
+      MNE_LOGGING_LEVEL: 'info'
+      OPENBLAS_NUM_THREADS: '1'
+      PYTHONUNBUFFERED: '1'
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade --upgrade-strategy eager -r requirements.txt
+          pip install --upgrade --upgrade-strategy eager -r requirements_testing.txt
+
+      - name: Install MNE (main)
+        if: "matrix.mne-version == 'mne-main'"
+        run: |
+          git clone --depth 1 https://github.com/mne-tools/mne-python.git -b main
+          pip install -e ./mne-python
+
+      - name: Display versions and environment information
+        run: |
+          echo $TZ
+          date
+          python --version
+          which python
+
+      - name: Install mne-icalabel
+        run: |
+          pip install --no-deps .
+
+      - shell: bash -el {0}
+        run: mne sys_info
+        name: 'Show infos'
+
+      - name: Run pytest
+        run: |
+          python -m pytest . --cov=mne_icalabel --cov-report=xml --cov-config=setup.cfg --verbose --ignore mne-python
+        shell: bash
+
+      - name: Upload coverage stats to codecov
+        if: "matrix.os == 'ubuntu-latest'"
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,116 @@
+# simple makefile to simplify repetetive build env management tasks under posix
+
+# caution: testing won't work on windows, see README
+
+PYTHON ?= python
+PYTESTS ?= py.test
+CTAGS ?= ctags
+CODESPELL_SKIPS ?= "*.fif,*.eve,*.gz,*.tgz,*.zip,*.mat,*.stc,*.label,*.w,*.bz2,*.annot,*.sulc,*.log,*.local-copy,*.orig_avg,*.inflated_avg,*.gii,*.pyc,*.doctree,*.pickle,*.inv,*.png,*.edf,*.touch,*.thickness,*.nofix,*.volume,*.defect_borders,*.mgh,lh.*,rh.*,COR-*,FreeSurferColorLUT.txt,*.examples,.xdebug_mris_calc,bad.segments,BadChannels,*.hist,empty_file,*.orig,*.js,*.map,*.ipynb,searchindex.dat,plot_*.rst,*.rst.txt,*.html,gdf_encodes.txt"
+CODESPELL_DIRS ?= mne_icalabel/ doc/ examples/
+all: clean inplace test test-doc
+
+clean-pyc:
+	find . -name "*.pyc" | xargs rm -f
+
+clean-so:
+	find . -name "*.so" | xargs rm -f
+	find . -name "*.pyd" | xargs rm -f
+
+clean-build:
+	rm -rf _build
+
+clean-ctags:
+	rm -f tags
+
+clean-cache:
+	find . -name "__pycache__" | xargs rm -rf
+
+clean: clean-build clean-pyc clean-so clean-ctags clean-cache
+
+in: inplace # just a shortcut
+inplace:
+	$(PYTHON) setup.py build_ext -i
+
+pytest: test
+
+test: in
+	rm -f .coverage
+	$(PYTESTS) mne_icalabel
+
+test-fast: in
+	rm -f .coverage
+	$(PYTESTS) -m 'not slowtest' mne
+
+test-full: in
+	rm -f .coverage
+	$(PYTESTS) mne
+
+test-no-network: in
+	sudo unshare -n -- sh -c 'MNE_SKIP_NETWORK_TESTS=1 py.test mne'
+
+test-no-testing-data: in
+	@MNE_SKIP_TESTING_DATASET_TESTS=true \
+	$(PYTESTS) mne
+
+test-no-sample-with-coverage: in testing_data
+	rm -rf coverage .coverage
+	$(PYTESTS) --cov=mne_icalabel --cov-report html:coverage
+
+test-doc: sample_data testing_data
+	$(PYTESTS) --doctest-modules --doctest-ignore-import-errors --doctest-glob='*.rst' ./doc/
+
+test-coverage: testing_data
+	rm -rf coverage .coverage
+	$(PYTESTS) --cov=mne_icalabel --cov-report html:coverage
+# whats the difference with test-no-sample-with-coverage?
+
+test-mem: in testing_data
+	ulimit -v 1097152 && $(PYTESTS) mne
+
+trailing-spaces:
+	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
+
+ctags:
+	# make tags for symbol based navigation in emacs and vim
+	# Install with: sudo apt-get install exuberant-ctags
+	$(CTAGS) -R *
+
+upload-pipy:
+	python setup.py sdist bdist_egg register upload
+
+flake:
+	@if command -v flake8 > /dev/null; then \
+		echo "Running flake8"; \
+		flake8 --count mne_icalabel examples; \
+	else \
+		echo "flake8 not found, please install it!"; \
+		exit 1; \
+	fi;
+	@echo "flake8 passed"
+
+codespell:  # running manually
+	@codespell -w -i 3 -q 3 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
+
+codespell-error:  # running on travis
+	@codespell -i 0 -q 7 -S $(CODESPELL_SKIPS) --ignore-words=ignore_words.txt $(CODESPELL_DIRS)
+
+pydocstyle:
+	@echo "Running pydocstyle"
+	@pydocstyle mne
+
+check-manifest:
+	check-manifest --ignore .circleci*,doc,logo,.DS_Store
+
+check-readme:
+	python setup.py check --restructuredtext --strict
+
+pep:
+	@$(MAKE) -k flake pydocstyle codespell-error check-manifest
+
+docstyle: pydocstyle
+
+build-doc:
+	@echo "Building documentation"
+	make -C doc/ clean
+	make -C doc/ html-noplot
+	cd doc/ && make view

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ICLabel-Python
 
+[![Codecov](https://codecov.io/gh/jacobf18/iclabel-python/branch/main/graph/badge.svg)](https://codecov.io/gh/jacobf18/iclabel-python)
+[![GitHub Actions](https://github.com/jacobf18/iclabel-python/workflows/build/badge.svg)](https://github.com/jacobf18/iclabel-python/actions)
+[![CircleCI](https://circleci.com/gh/jacobf18/iclabel-python.svg?style=shield)](https://circleci.com/gh/jacobf18/iclabel-python)
+[![PyPI Download count](https://pepy.tech/badge/mne-icalabel)](https://pepy.tech/project/mne-icalabel)
+[![Latest PyPI release](https://img.shields.io/pypi/v/mne-icalabel.svg)](https://pypi.org/project/mne-icalabel/)
+
 This repository is a conversion of the popular ICLabel classifier for python.
 
 ## Ports Completed

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,0 +1,4 @@
+Examples
+--------
+
+Examples demonstrating ICA labeling.

--- a/examples/automatic_artifact_correction_ica.py
+++ b/examples/automatic_artifact_correction_ica.py
@@ -3,7 +3,7 @@
 .. _tut-auto-artifact-ica:
 
 WIP: Repairing artifacts with ICA automatically
-==========================================
+===============================================
 
 This tutorial covers automatically repairing signals using ICA. For conceptual background on ICA, see
 :ref:`this scikit-learn tutorial

--- a/mne_icalabel/__init__.py
+++ b/mne_icalabel/__init__.py
@@ -5,6 +5,7 @@
 #
 # License: BSD (3-clause)
 
-__version__ = '0.3dev0'
+__version__ = '0.1dev0'
 
 from .ica_features import rpsd, autocorr_fftw, topoplot
+from .ica_label import eeg_features, ica_label

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,0 +1,14 @@
+memory_profiler
+sphinx
+sphinx-gallery
+sphinx_rtd_theme
+sphinx-copybutton
+numpydoc
+nibabel
+nilearn
+pydata-sphinx-theme
+typing-extensions
+sphinx-autodoc-typehints
+sphinxcontrib-bibtex
+https://github.com/mne-tools/mne-bids/archive/main.zip
+pooch


### PR DESCRIPTION
Not sure if the CIs are enabled on this PR until it merges in... but here's a try.

Note that I think to shorten the later-on work of turning this into a robust API, I would just develop the API necessary within the `mne_icalabel/` directory, so that `setup.py/cfg` can package it neatly down the line.

Didn't change anything related to code though, so once you have things working, lmk. We can clean up the repo and try to make the CIs pass